### PR TITLE
add support for datagrip 2019.2

### DIFF
--- a/mackup/applications/datagrip.cfg
+++ b/mackup/applications/datagrip.cfg
@@ -12,3 +12,4 @@ Library/Application Support/DataGrip2018.3
 Library/Preferences/DataGrip2018.3
 Library/Application Support/DataGrip2019.1
 Library/Preferences/DataGrip2019.1
+Library/Preferences/DataGrip2019.2


### PR DESCRIPTION
There doesent seem to be a new Library/Application Support/ folder for datagrip 2019.2 so i have only added the lib/preferences folder